### PR TITLE
Front end poa

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -11,7 +11,7 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Jazzy Elks</title>
+    <title>Pioneer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/assets/stylesheets/main.css
+++ b/client/src/assets/stylesheets/main.css
@@ -30307,12 +30307,12 @@ select {
 
 #modal-container {
   background: rgba(0,0, 0, 0.7);
-  position: absolute;
+  height: 100%;
   top: 0;
   bottom: 0;
   right: 0;
   left: 0;
-  overflow: auto;
+  overflow: hidden;
   z-index: 3;
 }
 

--- a/client/src/assets/stylesheets/main.css
+++ b/client/src/assets/stylesheets/main.css
@@ -26019,6 +26019,342 @@ select {
   --tw-placeholder-opacity: 1;
 }
 
+.caret-transparent {
+  caret-color: transparent;
+}
+
+.caret-current {
+  caret-color: currentColor;
+}
+
+.caret-black {
+  caret-color: #000;
+}
+
+.caret-white {
+  caret-color: #fff;
+}
+
+.caret-gray-50 {
+  caret-color: #f9fafb;
+}
+
+.caret-gray-100 {
+  caret-color: #f3f4f6;
+}
+
+.caret-gray-200 {
+  caret-color: #e5e7eb;
+}
+
+.caret-gray-300 {
+  caret-color: #d1d5db;
+}
+
+.caret-gray-400 {
+  caret-color: #9ca3af;
+}
+
+.caret-gray-500 {
+  caret-color: #6b7280;
+}
+
+.caret-gray-600 {
+  caret-color: #4b5563;
+}
+
+.caret-gray-700 {
+  caret-color: #374151;
+}
+
+.caret-gray-800 {
+  caret-color: #1f2937;
+}
+
+.caret-gray-900 {
+  caret-color: #111827;
+}
+
+.caret-red-50 {
+  caret-color: #fef2f2;
+}
+
+.caret-red-100 {
+  caret-color: #fee2e2;
+}
+
+.caret-red-200 {
+  caret-color: #fecaca;
+}
+
+.caret-red-300 {
+  caret-color: #fca5a5;
+}
+
+.caret-red-400 {
+  caret-color: #f87171;
+}
+
+.caret-red-500 {
+  caret-color: #ef4444;
+}
+
+.caret-red-600 {
+  caret-color: #dc2626;
+}
+
+.caret-red-700 {
+  caret-color: #b91c1c;
+}
+
+.caret-red-800 {
+  caret-color: #991b1b;
+}
+
+.caret-red-900 {
+  caret-color: #7f1d1d;
+}
+
+.caret-yellow-50 {
+  caret-color: #fffbeb;
+}
+
+.caret-yellow-100 {
+  caret-color: #fef3c7;
+}
+
+.caret-yellow-200 {
+  caret-color: #fde68a;
+}
+
+.caret-yellow-300 {
+  caret-color: #fcd34d;
+}
+
+.caret-yellow-400 {
+  caret-color: #fbbf24;
+}
+
+.caret-yellow-500 {
+  caret-color: #f59e0b;
+}
+
+.caret-yellow-600 {
+  caret-color: #d97706;
+}
+
+.caret-yellow-700 {
+  caret-color: #b45309;
+}
+
+.caret-yellow-800 {
+  caret-color: #92400e;
+}
+
+.caret-yellow-900 {
+  caret-color: #78350f;
+}
+
+.caret-green-50 {
+  caret-color: #ecfdf5;
+}
+
+.caret-green-100 {
+  caret-color: #d1fae5;
+}
+
+.caret-green-200 {
+  caret-color: #a7f3d0;
+}
+
+.caret-green-300 {
+  caret-color: #6ee7b7;
+}
+
+.caret-green-400 {
+  caret-color: #34d399;
+}
+
+.caret-green-500 {
+  caret-color: #10b981;
+}
+
+.caret-green-600 {
+  caret-color: #059669;
+}
+
+.caret-green-700 {
+  caret-color: #047857;
+}
+
+.caret-green-800 {
+  caret-color: #065f46;
+}
+
+.caret-green-900 {
+  caret-color: #064e3b;
+}
+
+.caret-blue-50 {
+  caret-color: #eff6ff;
+}
+
+.caret-blue-100 {
+  caret-color: #dbeafe;
+}
+
+.caret-blue-200 {
+  caret-color: #bfdbfe;
+}
+
+.caret-blue-300 {
+  caret-color: #93c5fd;
+}
+
+.caret-blue-400 {
+  caret-color: #60a5fa;
+}
+
+.caret-blue-500 {
+  caret-color: #3b82f6;
+}
+
+.caret-blue-600 {
+  caret-color: #2563eb;
+}
+
+.caret-blue-700 {
+  caret-color: #1d4ed8;
+}
+
+.caret-blue-800 {
+  caret-color: #1e40af;
+}
+
+.caret-blue-900 {
+  caret-color: #1e3a8a;
+}
+
+.caret-indigo-50 {
+  caret-color: #eef2ff;
+}
+
+.caret-indigo-100 {
+  caret-color: #e0e7ff;
+}
+
+.caret-indigo-200 {
+  caret-color: #c7d2fe;
+}
+
+.caret-indigo-300 {
+  caret-color: #a5b4fc;
+}
+
+.caret-indigo-400 {
+  caret-color: #818cf8;
+}
+
+.caret-indigo-500 {
+  caret-color: #6366f1;
+}
+
+.caret-indigo-600 {
+  caret-color: #4f46e5;
+}
+
+.caret-indigo-700 {
+  caret-color: #4338ca;
+}
+
+.caret-indigo-800 {
+  caret-color: #3730a3;
+}
+
+.caret-indigo-900 {
+  caret-color: #312e81;
+}
+
+.caret-purple-50 {
+  caret-color: #f5f3ff;
+}
+
+.caret-purple-100 {
+  caret-color: #ede9fe;
+}
+
+.caret-purple-200 {
+  caret-color: #ddd6fe;
+}
+
+.caret-purple-300 {
+  caret-color: #c4b5fd;
+}
+
+.caret-purple-400 {
+  caret-color: #a78bfa;
+}
+
+.caret-purple-500 {
+  caret-color: #8b5cf6;
+}
+
+.caret-purple-600 {
+  caret-color: #7c3aed;
+}
+
+.caret-purple-700 {
+  caret-color: #6d28d9;
+}
+
+.caret-purple-800 {
+  caret-color: #5b21b6;
+}
+
+.caret-purple-900 {
+  caret-color: #4c1d95;
+}
+
+.caret-pink-50 {
+  caret-color: #fdf2f8;
+}
+
+.caret-pink-100 {
+  caret-color: #fce7f3;
+}
+
+.caret-pink-200 {
+  caret-color: #fbcfe8;
+}
+
+.caret-pink-300 {
+  caret-color: #f9a8d4;
+}
+
+.caret-pink-400 {
+  caret-color: #f472b6;
+}
+
+.caret-pink-500 {
+  caret-color: #ec4899;
+}
+
+.caret-pink-600 {
+  caret-color: #db2777;
+}
+
+.caret-pink-700 {
+  caret-color: #be185d;
+}
+
+.caret-pink-800 {
+  caret-color: #9d174d;
+}
+
+.caret-pink-900 {
+  caret-color: #831843;
+}
+
 .opacity-0 {
   opacity: 0;
 }
@@ -29963,6 +30299,10 @@ select {
 
 .ease-in-out {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.content-none {
+  content: none;
 }
 
 #modal-container {

--- a/client/src/assets/stylesheets/tailwind.css
+++ b/client/src/assets/stylesheets/tailwind.css
@@ -6,12 +6,12 @@
 
 #modal-container {
   background: rgba(0,0, 0, 0.7);
-  position: absolute;
+  height: 100%;
   top: 0;
   bottom: 0;
   right: 0;
   left: 0;
-  overflow: auto;
+  overflow: hidden;
   z-index: 3;
 }
 

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import '../App.css';
 
 import Sidebar from './Sidebar';
 import Flags from './dashboardComponents/Flags';
 import Logs from  './logComponents/Logs';
 import SingleFlag from './flagViewComponents/SingleFlag';
+import NotFound from './errorHandling/404';
 
 function App() {
   return (
@@ -13,10 +14,13 @@ function App() {
       <div className="hidden md:flex md:flex-shrink-0 min-h-screen">
         <Sidebar />
         <div className="main w-full mx-auto sm:px-6 lg:px-8">
-          <Route path="/" exact component={Flags} />
-          <Route path="/flags" exact component={Flags} />
-          <Route path="/flags/:id" exact component={SingleFlag} />
-          <Route path="/logs" exact component={Logs} />
+          <Switch>
+            <Route path="/" exact component={Flags} />
+            <Route path="/flags" exact component={Flags} />
+            <Route path="/flags/:id" exact component={SingleFlag} />
+            <Route path="/logs" exact component={Logs} />
+            <Route path="*" component={NotFound} />
+          </Switch>
         </div>
       </div>
     </>

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
 
+const isCurrentPage = (href) => {
+  const currentPath = window.location.pathname;
+  return href === currentPath;
+}
+
 const Sidebar = () => {
   return(
       <div className="flex flex-col w-64">
@@ -8,8 +13,8 @@ const Sidebar = () => {
             <div className="flex items-center flex-shrink-0 px-4">
               <img className="h-8 w-auto" src="https://tailwindui.com/img/logos/workflow-logo-indigo-500-mark-white-text.svg" alt="Workflow"></img>
             </div>
-            <nav className="mt-5 flex-1 px-2 bg-gray-800 space-y-1">
-              <a href="/flags" className="bg-gray-900 text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+            <nav className='mt-5 flex-1 px-2 space-y-1 bg-gray-800'>
+              <a href="/flags" className={`${(isCurrentPage('/flags') || isCurrentPage('/')) ? 'bg-gray-900' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md`}>
 
                 <svg className="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
@@ -17,14 +22,14 @@ const Sidebar = () => {
                 Dashboard
               </a>
 
-              <a href="/logs" className="text-gray-300 hover:bg-gray-700 hover:text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+              <a href="/logs" className={`${isCurrentPage('/logs') ? 'bg-gray-900' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md`}>
                 <svg className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
                 </svg>
                 Logs
               </a>
 
-              <a href="/docs" className="text-gray-300 hover:bg-gray-700 hover:text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+              {/* <a href="/docs" className="text-gray-300 hover:bg-gray-700 hover:text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md">
                 <svg className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
                 </svg>
@@ -36,7 +41,7 @@ const Sidebar = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
               </svg>
                 Account
-              </a>
+              </a> */}
             </nav>
           </div>
         </div>

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -7,46 +7,33 @@ const isCurrentPage = (href) => {
 
 const Sidebar = () => {
   return(
-      <div className="flex flex-col w-64">
-        <div className="flex flex-col h-0 flex-1 bg-gray-800">
-          <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
-            <div className="flex items-center flex-shrink-0 px-4">
-              <img className="h-8 w-auto" src="https://tailwindui.com/img/logos/workflow-logo-indigo-500-mark-white-text.svg" alt="Workflow"></img>
-            </div>
-            <nav className='mt-5 flex-1 px-2 space-y-1 bg-gray-800'>
-              <a href="/flags" className={`${(isCurrentPage('/flags') || isCurrentPage('/')) ? 'bg-gray-900' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md`}>
-
-                <svg className="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                </svg>
-                Dashboard
-              </a>
-
-              <a href="/logs" className={`${isCurrentPage('/logs') ? 'bg-gray-900' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md`}>
-                <svg className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                </svg>
-                Logs
-              </a>
-
-              {/* <a href="/docs" className="text-gray-300 hover:bg-gray-700 hover:text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                <svg className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-                </svg>
-                Documentation
-              </a>
-
-              <a href="/account" className="text-gray-300 hover:bg-gray-700 hover:text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-              <svg xmlns="http://www.w3.org/2000/svg" className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
-              </svg>
-                Account
-              </a> */}
-            </nav>
+    <div className="flex flex-col w-64">
+      <div className="flex flex-col h-0 flex-1 bg-gray-800">
+        <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
+          <div className=" items-center flex-shrink-0 px-4">
+            <h1 className="text-white text-xl block">Pioneer</h1>
+            <p className="text-white block">Logo goes here?</p>
+            {/* <img className="h-8 w-auto" src="https://tailwindui.com/img/logos/workflow-logo-indigo-500-mark-white-text.svg" alt="Workflow"></img> */}
           </div>
+          <nav className='mt-5 flex-1 px-2 space-y-1 bg-gray-800'>
+            <a href="/flags" className={`${(isCurrentPage('/flags') || isCurrentPage('/')) ? 'bg-gray-900' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md`}>
+
+              <svg className="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+              Dashboard
+            </a>
+
+            <a href="/logs" className={`${isCurrentPage('/logs') ? 'bg-gray-900' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md`}>
+              <svg className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              Logs
+            </a>
+          </nav>
         </div>
       </div>
-
+    </div>
   );
 };
 

--- a/client/src/components/dashboardComponents/Flags.jsx
+++ b/client/src/components/dashboardComponents/Flags.jsx
@@ -18,7 +18,7 @@ const Flags = () => {
   return (
     <>
         <FlagsHeader setCreatingNew={setCreatingNew} />
-        <NewFlagForm creatingNew={creatingNew} setCreatingNew={setCreatingNew} />
+        <NewFlagForm creatingNew={creatingNew} setCreatingNew={setCreatingNew} existingFlags={flagList} />
         <section className="flag-container">
           <ul className="p-8 flag-tiles divide-y divide-gray-200">
             {flagList.map(flag => <Flag {...flag} key={flag.id} />)}

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { createFlag } from '../../actions/FlagActions';
 
 
-const NewFlagForm = ({creatingNew, setCreatingNew}) => {
+const NewFlagForm = ({creatingNew, setCreatingNew, existingFlags}) => {
   const [ flagTitle, setFlagTitle ] = useState('');
   const [ flagDescription, setFlagDescription ] = useState('');
   const dispatch = useDispatch();
@@ -18,9 +18,17 @@ const NewFlagForm = ({creatingNew, setCreatingNew}) => {
     setFlagTitle('');
   };
 
+  const nameIsUnique = (newFlagTitle) => {
+    newFlagTitle = newFlagTitle.toLowerCase();
+    return existingFlags.every(flag => flag.title.toLowerCase() !== newFlagTitle);
+  };
+
   const handleSubmit = () => {
     if (flagTitle === '') {
       alert("You must have a flag title");
+      return;
+    } else if (!nameIsUnique(flagTitle)) {
+      alert(`The flag name ${flagTitle} has already been used. Please choose another.`);
       return;
     }
 

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -48,7 +48,7 @@ const NewFlagForm = ({creatingNew, setCreatingNew, existingFlags}) => {
   }
 
   return(
-    <div id="modal-container" className={`${creatingNew ? "" : "hidden"}`}>
+    <div id="modal-container" className={`overflow-scroll fixed ${creatingNew ? "" : "hidden"}`}>
       <div id="modal">
         <form className="space-y-8 divide-y divide-gray-200 m-8">
           <div className="space-y-8 divide-y divide-gray-200 sm:space-y-5 p-6">

--- a/client/src/components/errorHandling/404.jsx
+++ b/client/src/components/errorHandling/404.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const NotFound = () => {
+  return(
+    <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div className="mx-auto w-2/3 h-1/3 my-40 content-center">
+        <h1 className="text-9xl mt-20 text-center text-green-700">404</h1>
+        <h2 className="text-center text-5xl text-gray-700">Oops! This page cannot be found.</h2>
+        <p className="mt-10 text-center text-xl text-gray-700">Return to
+          <a className="text-green-700" href="/"> dashboard</a>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound

--- a/client/src/components/errorHandling/500.jsx
+++ b/client/src/components/errorHandling/500.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const ServerError = () => {
+  return(
+    <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div className="mx-auto w-2/3 h-1/3 my-40 content-center">
+        <h1 className="text-9xl mt-20 text-center text-green-700">500</h1>
+        <h2 className="text-center text-5xl text-gray-700">Jeepers! There's been a server error. Contact an admin to check the server logs.</h2>
+        <p className="mt-10 text-center text-xl text-gray-700">Return to
+          <a className="text-green-700" href="/"> dashboard</a>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ServerError;

--- a/client/src/components/flagViewComponents/SingleFlag.jsx
+++ b/client/src/components/flagViewComponents/SingleFlag.jsx
@@ -7,7 +7,7 @@ import SingleFlagLogs from './SingleFlagLogs';
 import Toggle from '../Toggle';
 import { updateFlag } from '../../actions/FlagActions';
 import { getFlag } from '../../actions/FlagActions';
-import { fetchLogs, logFlagDeletion } from '../../actions/LogActions';
+import { fetchLogs } from '../../actions/LogActions';
 import { parseDate } from '../../lib/helpers';
 
 

--- a/client/src/components/flagViewComponents/SingleFlag.jsx
+++ b/client/src/components/flagViewComponents/SingleFlag.jsx
@@ -21,7 +21,7 @@ const SingleFlag = (props) => {
 	const [ flagToggled, setFlagToggled ] = useState(false);
 
   const flag = useSelector(state => state.flags).find(flag => flag.id === flagId);
-  const logs = useSelector(state => state.eventLogs).filter(event => event.flag_id === flagId);
+  const logs = useSelector(state => state.eventLogs).filter(event => event.flag_id === flagId).reverse();
 
   const handleDeleteFlag = () => {
 		setDeletingFlag(true)
@@ -71,7 +71,7 @@ const SingleFlag = (props) => {
             </dt>
             <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
               {flag.is_active ? "On" : "Off"}
-							<Toggle toggledOn={flag.is_active} _id={flag.id} handleClickToggle={handleClickToggle} />	
+							<Toggle toggledOn={flag.is_active} _id={flag.id} handleClickToggle={handleClickToggle} />
             </dd>
           </div>
           <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/client/src/components/logComponents/Logs.jsx
+++ b/client/src/components/logComponents/Logs.jsx
@@ -5,7 +5,8 @@ import LogEvent from './LogEvent';
 import LogsHeader from './LogsHeader';
 
 const Logs = () => {
-  const logEvents = useSelector(state => state.eventLogs);
+  // reverse so most recent events are displayed first
+  const logEvents = useSelector(state => state.eventLogs).reverse();
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "pioneer",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "react-router-redux": "^4.0.8"
+      }
+    },
+    "node_modules/react-router-redux": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-4.0.8.tgz",
+      "integrity": "sha1-InQDWWtRUeGCN32rg1tdRfD4BU4="
+    }
+  },
+  "dependencies": {
+    "react-router-redux": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-4.0.8.tgz",
+      "integrity": "sha1-InQDWWtRUeGCN32rg1tdRfD4BU4="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react-router-redux": "^4.0.8"
+  }
+}


### PR DESCRIPTION
This PR addresses a handful of minor front-end issues:

- logs are displayed in reverse chronological order on both the `/logs` page as well as the `/flags/:id` page (most recent displayed at top).
- correct tab is highlighted on sidebar
- remove some boiler plate from dashboard template
- 404 and 500 components are created. 404 is displayed when user visits an invalid route. There will need to be additional code added to display the 404/500 components when these errors arise on the server-side.
- front-end validation was added so users cannot create a new flag with the same name as an existing flag.