### PR TITLE
Db bug fixes

### DIFF
--- a/client/src/actions/FlagActions.js
+++ b/client/src/actions/FlagActions.js
@@ -89,7 +89,6 @@ export function createFlag(flagData, callback) {
 	return function(dispatch) {
 		dispatch(createFlagRequest());
 		apiClient.createFlag(flagData, (resData) => {
-			console.log('create flag resdata :', resData);
 			dispatch(createFlagSuccess(resData));
 
 			if (callback) {

--- a/client/src/components/dashboardComponents/Flag.jsx
+++ b/client/src/components/dashboardComponents/Flag.jsx
@@ -4,7 +4,7 @@ import Toggle from '../Toggle';
 import { updateFlag } from '../../actions/FlagActions';
 import { parseDate, truncate } from '../../lib/helpers';
 
-const Flag = ({ id, title, description, is_active, created_at }) => {
+const Flag = ({ id, title, description, is_active, created_at, updated_at }) => {
 	const dispatch = useDispatch();
 
 	const handleClickToggle = (e) => {
@@ -21,6 +21,7 @@ const Flag = ({ id, title, description, is_active, created_at }) => {
 			<Toggle toggledOn={is_active} _id={id} handleClickToggle={handleClickToggle} />
 			<p>Description: {truncate(description)}</p>
 			<p>Created: {parseDate(created_at)}</p>
+			<p>Last updated: {parseDate(updated_at)}</p>
 		</li>
 	);
 };

--- a/client/src/components/dashboardComponents/Flags.jsx
+++ b/client/src/components/dashboardComponents/Flags.jsx
@@ -5,11 +5,24 @@ import Flag from './Flag';
 import FlagsHeader from './FlagsHeader';
 import NewFlagForm from './NewFlagForm';
 
+const sortFlags = (flagList) => {
+  flagList.sort((a, b) => {
+    if (a.updated_at < b.updated_at) {
+      return 1
+    } else if (a.updated_at > b.updated_at) {
+      return -1
+    } else {
+      return 0
+    }
+  });
+
+  return flagList
+}
+
 const Flags = () => {
-  const flagList = useSelector(state => state.flags);
+  const flagList = sortFlags(useSelector(state => state.flags));
   const dispatch = useDispatch();
   const [creatingNew, setCreatingNew] = useState(false);
-
 
   useEffect(() => {
     dispatch(fetchFlags());

--- a/client/src/components/dashboardComponents/FlagsHeader.jsx
+++ b/client/src/components/dashboardComponents/FlagsHeader.jsx
@@ -7,7 +7,7 @@ const FlagsHeader = ({setCreatingNew}) => {
         <h3 className="block text-5xl leading-14 font-medium text-green-700">
           Feature Flags
         </h3>
-        <p className="pt-4 leading-6 block">Click a flag title to view full details</p>
+        <p className="pt-4 leading-6 block">Click a flag title to view full details. The most recently updated flags can be found at the top of this list.</p>
       </div>
       <div className="mt-3 sm:mt-0 sm:ml-4">
         <button onClick={() => setCreatingNew(true) }type="button" className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">

--- a/client/src/reducers/flags.js
+++ b/client/src/reducers/flags.js
@@ -15,7 +15,6 @@ export default function flags(state = [], action) {
 		}
 		case 'CREATE_FLAG_SUCCESS': {
 			const newFlag = action.flag;
-			console.log('reducer create flag: ', newFlag.flag);
 			return state.concat(newFlag);
 		}
 		case 'UPDATE_FLAG_SUCCESS': {

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -10,7 +10,7 @@ $$ language 'plpgsql';
 CREATE TABLE IF NOT EXISTS Flags (
   id serial,
   title varchar(100) NOT NULL,
-  description text DEFAULT 'No description provided.' NOT NULL,
+  description text NOT NULL DEFAULT 'No description provided.',
   is_active boolean DEFAULT false NOT NULL,
   version int DEFAULT 1,
   updated_at timestamp with time zone NOT NULL DEFAULT current_timestamp,

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,11 +1,20 @@
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+
 CREATE TABLE IF NOT EXISTS Flags (
   id serial,
   title varchar(100) NOT NULL,
-  description text DEFAULT 'No description provided.',
+  description text DEFAULT 'No description provided.' NOT NULL,
   is_active boolean DEFAULT false NOT NULL,
   version int DEFAULT 1,
-  updated_at timestamp DEFAULT NOW(),
-  created_at timestamp DEFAULT NOW(),
+  updated_at timestamp with time zone NOT NULL DEFAULT current_timestamp,
+  created_at timestamp with time zone NOT NULL DEFAULT current_timestamp,
   PRIMARY KEY (id)
 );
 CREATE TABLE IF NOT EXISTS Strategies (
@@ -22,9 +31,13 @@ CREATE TABLE IF NOT EXISTS Logs (
   description varchar(100) NOT NULL,
   created_at timestamp DEFAULT NOW(),
   PRIMARY KEY (id)
-  -- we should preserve logs for deletions.. history will be weird otherwise
-  -- FOREIGN KEY (flag_id) REFERENCES Flags(id) ON DELETE CASCADE
 );
+
+CREATE TRIGGER tg_flags_updated_at
+  BEFORE UPDATE
+  ON flags
+  FOR EACH ROW
+  EXECUTE PROCEDURE update_updated_at_column();
 
 INSERT INTO Flags(title, description, is_active) VALUES ('LOGIN_MICROSERVICE', 'Redirects users to the login microservice', FALSE);
 INSERT INTO Strategies(flag_id, percentage) VALUES (1, 0.1);

--- a/server/lib/postgres-flags.js
+++ b/server/lib/postgres-flags.js
@@ -27,9 +27,9 @@ async function fetchFlag(id) {
 
 async function updateFlagDb(id, title, description, isActive) {
 	const QUERY_STRING =
-		'UPDATE Flags SET (title, description, is_active, updated_at) = ($2, $3, $4, to_timestamp($5)) WHERE id = $1';
-	const updatedAt = Date.now();
-	const params = [ id, title, description, isActive, updatedAt ];
+		'UPDATE Flags SET (title, description, is_active) = ($2, $3, $4) WHERE id = $1';
+
+	const params = [ id, title, description, isActive ];
 	const result = await postgresQuery(QUERY_STRING, params);
 
 	// IMPORTANT: update and delete queries result in empty rows but rowCount > 0;


### PR DESCRIPTION
**NOTE init.sql is now updated. If you're building your psql container locally, make sure to update the init.sql you're using**

This PR addresses some bugs that were in the DB:

- The flags' table `updated_at` column now has a 'trigger' function, that will automatically update the column with the appropriate timestamp when a flag is updated.
- The flag index now displays flags ordered by most recent update. Those updated most recently will be at the top of the list.
- The application was passing in a default description value of `''` for flags.  This resulted n the database's default value (`'No description provided.'`) never being used.  The application now will use the default value for the database column if the user does not have one or more non-whitespace characters in their flag description when saving a new flag.