### PR TITLE
New jetstream workflow

### DIFF
--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -1,6 +1,6 @@
 const HttpError = require('../models/httpError');
 const { validationResult } = require('express-validator');
-const { publish } = require('../lib/nats-pub');
+const { publishUpdatedRules } = require('../lib/nats-pub');
 const { createFlagDb, fetchAllFlags, fetchFlag, updateFlagDb, deleteFlagDb } = require('../lib/postgres-flags');
 
 const getFlags = async (req, res, next) => {

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -31,7 +31,7 @@ const createFlag = async (req, res, next) => {
 		await createFlagDb(title, description)
 			.then((flag) => {
 				req.flag = flag;
-				publish('FLAG.created', `New flag created. Data: ${JSON.stringify(flag)}`);
+				publishUpdatedRules();
 				next();
 			})
 			.catch((err) => {
@@ -66,7 +66,7 @@ const updateFlag = async (req, res, next) => {
 				req.flag = flag;
 				req.toggleChange = toggleChange;
 
-				publish('FLAG.updated', `Flag updated. Data: ${JSON.stringify(flag)}`);
+				publishUpdatedRules();
 				next();
 			})
 			.catch((err) => next(new HttpError('Updating flag failed, please try again', 500)));
@@ -82,7 +82,7 @@ const deleteFlag = async (req, res, next) => {
 	await deleteFlagDb(id)
 		.then((deleteSuccess) => {
 			if (deleteSuccess) {
-				publish('FLAG.deleted', `${id}`);
+				publishUpdatedRules();
 
 				res.send({ id });
 			} else {

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const HttpError = require('./models/httpError');
 const routes = require('./routes/api');
-const { publishInit } = require('./lib/nats-pub');
+const { publishUpdatedRules } = require('./lib/nats-pub');
 require('dotenv').config();
 
 const app = express();
@@ -32,5 +32,5 @@ app.use((err, req, res, next) => {
 
 app.listen(PORT, () => {
 	console.log(`Server listening on ${PORT}`);
-	publishInit();
+	publishUpdatedRules();
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const HttpError = require('./models/httpError');
 const routes = require('./routes/api');
-const { publishUpdatedRules } = require('./lib/nats-pub');
+const { publishUpdatedRules, subscribeToRuleSetRequests } = require('./lib/nats-pub');
 require('dotenv').config();
 
 const app = express();
@@ -33,4 +33,5 @@ app.use((err, req, res, next) => {
 app.listen(PORT, () => {
 	console.log(`Server listening on ${PORT}`);
 	publishUpdatedRules();
+	subscribeToRuleSetRequests();
 });

--- a/server/lib/jetstreamManager.js
+++ b/server/lib/jetstreamManager.js
@@ -38,5 +38,6 @@ async function streamsCreated() {
 
 
 
+
 exports.createStreams = createStreams;
 exports.streamsCreated= streamsCreated;

--- a/server/lib/jetstreamManager.js
+++ b/server/lib/jetstreamManager.js
@@ -1,24 +1,14 @@
 const { connect } = require("nats");
 
 async function createStreams() {
-  console.log("create streams executing")
   const nc = await connect({ servers: "localhost:4222" });
-
-  // create a jetstream manager - manages stream configs
   const jsm = await nc.jetstreamManager();
 
-  // create a stream with the name 'FLAG',
-  // which streams all messages with a subject name that starts with 'FLAG'
-  // and the messages are stored in memory (not disk)
-  jsm.streams.add({name: "FLAG", subjects: ["FLAG.*"], storage: "memory"})
   jsm.streams.add({name: "DATA", subjects: ["DATA.*"], storage: "memory"})
   
   
-  // retrieve info about the stream
-  const flagStreamInfo = await jsm.streams.info("FLAG")
   const dataStreamInfo = await jsm.streams.info("DATA")
 
-  console.log("FLAG stream info", flagStreamInfo)
   console.log("DATA stream info", dataStreamInfo)
 }
 
@@ -26,14 +16,12 @@ async function streamsCreated() {
   const nc = await connect({ servers: "localhost:4222" });
   const jsm = await nc.jetstreamManager();
 
-  let flag;
   let data;
 
   try {
     data = await jsm.streams.info("DATA")
-    flag = await jsm.streams.info("FLAG")
 
-    return flag.config.name === "FLAG" && data.config.name === "DATA";
+    return data.config.name === "DATA";
   } catch(err) {
     console.log("stream not created.", err);
     return false;

--- a/server/lib/jetstreamManager.js
+++ b/server/lib/jetstreamManager.js
@@ -1,4 +1,4 @@
-const { connect } = require("nats");
+const { connect, AckPolicy } = require("nats");
 
 async function createStreams() {
   const nc = await connect({ servers: "localhost:4222" });
@@ -9,7 +9,15 @@ async function createStreams() {
   
   const dataStreamInfo = await jsm.streams.info("DATA")
 
+  await addConsumers(jsm);
   console.log("DATA stream info", dataStreamInfo)
+}
+
+async function addConsumers(jsm) {
+  await jsm.consumers.add('DATA', {
+    durable_name: "dataStream",
+    ack_policy: AckPolicy.Explicit,
+  });
 }
 
 async function streamsCreated() {

--- a/server/lib/nats-pub.js
+++ b/server/lib/nats-pub.js
@@ -2,22 +2,22 @@ const {connect, StringCodec, JSONCodec} = require("nats");
 const sc = StringCodec();
 const jc = JSONCodec();
 const   {createStreams, streamsCreated} = require("./jetstreamManager")
+const {fetchAllFlags} = require("./postgres-flags")
 
 // publishing to jetstream
-async function publish(stream, msg) {
+async function publishUpdatedRules() {
   const nc = await connect({ servers: "localhost:4222" });
-
-  // create jetstream client
   const js = nc.jetstream();
   
-  // if streams have not already been created, then create them
+  
   if (! await streamsCreated()) {
     await createStreams();
   }
 
-  console.log(`Publishing this msg: ${msg} to this stream: ${stream}`)
+  const flagData = await fetchAllFlags();
+  console.log(`Publishing this msg: ${flagData} to this stream: ${DATA.FullRuleSet}`)
 
-  const pubMsg = await js.publish(stream, sc.encode(msg))
+  const pubMsg = await js.publish(DATA.FullRuleSet, sc.encode(flagData))
 
   // should capture the stream that captured the message
   // and sequence assigned to msg
@@ -34,7 +34,7 @@ async function publishInit(data) {
   const js = nc.jetstream();
   
   
-  // if streams have not already been created, then create them
+
   if (! await streamsCreated()) {
     await createStreams();
   }
@@ -43,5 +43,5 @@ async function publishInit(data) {
   console.log("DATA.init msg sent");
 }
 
-exports.publish = publish;
+exports.publishUpdatedRules = publishUpdatedRules;
 exports.publishInit = publishInit;

--- a/server/lib/nats-pub.js
+++ b/server/lib/nats-pub.js
@@ -20,13 +20,6 @@ async function publishUpdatedRules() {
 
   const pubMsg = await js.publish('DATA.FullRuleSet', sc.encode(flagData))
 
-  // should capture the stream that captured the message
-  // and sequence assigned to msg
-  const capStream = pubMsg.stream;
-  const msgSeq = pubMsg.seq;
-
-  console.log(`Msg was captured by stream "${capStream}" and is seq num: ${msgSeq}`)
-
   await nc.drain();
 }
 

--- a/server/lib/nats-pub.js
+++ b/server/lib/nats-pub.js
@@ -1,4 +1,4 @@
-const {connect, StringCodec, JSONCodec} = require("nats");
+const {connect, StringCodec, JSONCodec, consumerOpts, createInbox} = require("nats");
 const sc = StringCodec();
 const jc = JSONCodec();
 const   {createStreams, streamsCreated} = require("./jetstreamManager")
@@ -23,5 +23,29 @@ async function publishUpdatedRules() {
   await nc.drain();
 }
 
+async function subscribeToRuleSetRequests() {
+  const nc = await connect({ servers: "localhost:4222" });
+  const js = nc.jetstream();
+
+  const sub = await js.subscribe('DATA.FullRuleSetRequest', config('FullRuleSetRequest'));
+
+  (async (sub) => {
+    for await (const m of sub) {
+      publishUpdatedRules();
+      m.ack();
+    };
+  })(sub);
+}
+
+function config(subject) {
+  const opts = consumerOpts();
+  opts.durable(subject);
+  opts.manualAck();
+  opts.ackExplicit();
+  opts.deliverTo(createInbox());
+
+  return opts
+}
 
 exports.publishUpdatedRules = publishUpdatedRules;
+exports.subscribeToRuleSetRequests = subscribeToRuleSetRequests;

--- a/server/lib/nats-pub.js
+++ b/server/lib/nats-pub.js
@@ -29,19 +29,5 @@ async function publishUpdatedRules() {
   await nc.drain();
 }
 
-async function publishInit(data) {
-  const nc = await connect({ servers: "localhost:4222" });
-  const js = nc.jetstream();
-  
-  
-
-  if (! await streamsCreated()) {
-    await createStreams();
-  }
-
-  await js.publish("DATA.init", jc.encode(data));
-  console.log("DATA.init msg sent");
-}
 
 exports.publishUpdatedRules = publishUpdatedRules;
-exports.publishInit = publishInit;

--- a/server/lib/nats-pub.js
+++ b/server/lib/nats-pub.js
@@ -14,10 +14,11 @@ async function publishUpdatedRules() {
     await createStreams();
   }
 
-  const flagData = await fetchAllFlags();
-  console.log(`Publishing this msg: ${flagData} to this stream: ${DATA.FullRuleSet}`)
+  let flagData = await fetchAllFlags();
+  flagData = JSON.stringify(flagData);
+  console.log(`Publishing this msg: ${(flagData)} to this stream: 'DATA.FullRuleSet'`)
 
-  const pubMsg = await js.publish(DATA.FullRuleSet, sc.encode(flagData))
+  const pubMsg = await js.publish('DATA.FullRuleSet', sc.encode(flagData))
 
   // should capture the stream that captured the message
   // and sequence assigned to msg

--- a/server/lib/postgres-query.js
+++ b/server/lib/postgres-query.js
@@ -28,5 +28,5 @@ const postgresQuery = async(statement, parameters) => {
 }
 
 module.exports = {
-  postgresQuery,
+  postgresQuery
 };

--- a/server/lib/postgres-query.js
+++ b/server/lib/postgres-query.js
@@ -28,5 +28,5 @@ const postgresQuery = async(statement, parameters) => {
 }
 
 module.exports = {
-  postgresQuery
+  postgresQuery,
 };


### PR DESCRIPTION
@kaledoux @jimzhe842 
This new jetstream workflow performs the following:
- Establishes the `DATA` stream when the app starts running
- Publishes a jetstream message containing the full feature flag rule set whenever a flag change occurs on the GUI
- Subscribes to messages requesting the full ruleset (message is sent by `scout` when an SDK client connects) and upon receipt, publishes the same jetstream message as above.
