### PR TITLE
Set the jetstream DATA stream to have a max of one message. 

### DIFF
--- a/server/lib/jetstreamManager.js
+++ b/server/lib/jetstreamManager.js
@@ -11,7 +11,7 @@ async function createStreams() {
   await createJetStreamConnect();
   const jsm = await nc.jetstreamManager();
 
-  jsm.streams.add({name: "DATA", subjects: ["DATA.*"], storage: "memory"})
+  jsm.streams.add({name: "DATA", subjects: ["DATA.*"], storage: "memory", max_msgs: 1}); //max_age: 300000000
   
   
   const dataStreamInfo = await jsm.streams.info("DATA")


### PR DESCRIPTION
Solved the problem of the DATA jetstream holding all previous messages by setting the stream configs to have a maximum of one message. Any time a new message is added to the stream, the oldest message is removed. This means the stream now only holds a single message, which is the most recent one.

Note: in order for this change to take effect you'll need to restart the nats docker container. 