### PR TITLE
Flags title property enforces uniqueness on backend as safeguard

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -9,7 +9,7 @@ $$ language 'plpgsql';
 
 CREATE TABLE IF NOT EXISTS Flags (
   id serial,
-  title varchar(100) NOT NULL,
+  title varchar(100) NOT NULL UNIQUE,
   description text NOT NULL DEFAULT 'No description provided.',
   is_active boolean DEFAULT false NOT NULL,
   version int DEFAULT 1,


### PR DESCRIPTION
Very small change to the schema of `Flags` to disallow duplicated titles. Front end validation should keep this in check, but it doesn't hurt to have this as a backup, just in case!

Note: the Postgres docker will need to be reset for this change to be applied.