### PR TITLE
Condense flag forms

### DIFF
--- a/client/src/assets/stylesheets/main.css
+++ b/client/src/assets/stylesheets/main.css
@@ -26019,6 +26019,342 @@ select {
   --tw-placeholder-opacity: 1;
 }
 
+.caret-transparent {
+  caret-color: transparent;
+}
+
+.caret-current {
+  caret-color: currentColor;
+}
+
+.caret-black {
+  caret-color: #000;
+}
+
+.caret-white {
+  caret-color: #fff;
+}
+
+.caret-gray-50 {
+  caret-color: #f9fafb;
+}
+
+.caret-gray-100 {
+  caret-color: #f3f4f6;
+}
+
+.caret-gray-200 {
+  caret-color: #e5e7eb;
+}
+
+.caret-gray-300 {
+  caret-color: #d1d5db;
+}
+
+.caret-gray-400 {
+  caret-color: #9ca3af;
+}
+
+.caret-gray-500 {
+  caret-color: #6b7280;
+}
+
+.caret-gray-600 {
+  caret-color: #4b5563;
+}
+
+.caret-gray-700 {
+  caret-color: #374151;
+}
+
+.caret-gray-800 {
+  caret-color: #1f2937;
+}
+
+.caret-gray-900 {
+  caret-color: #111827;
+}
+
+.caret-red-50 {
+  caret-color: #fef2f2;
+}
+
+.caret-red-100 {
+  caret-color: #fee2e2;
+}
+
+.caret-red-200 {
+  caret-color: #fecaca;
+}
+
+.caret-red-300 {
+  caret-color: #fca5a5;
+}
+
+.caret-red-400 {
+  caret-color: #f87171;
+}
+
+.caret-red-500 {
+  caret-color: #ef4444;
+}
+
+.caret-red-600 {
+  caret-color: #dc2626;
+}
+
+.caret-red-700 {
+  caret-color: #b91c1c;
+}
+
+.caret-red-800 {
+  caret-color: #991b1b;
+}
+
+.caret-red-900 {
+  caret-color: #7f1d1d;
+}
+
+.caret-yellow-50 {
+  caret-color: #fffbeb;
+}
+
+.caret-yellow-100 {
+  caret-color: #fef3c7;
+}
+
+.caret-yellow-200 {
+  caret-color: #fde68a;
+}
+
+.caret-yellow-300 {
+  caret-color: #fcd34d;
+}
+
+.caret-yellow-400 {
+  caret-color: #fbbf24;
+}
+
+.caret-yellow-500 {
+  caret-color: #f59e0b;
+}
+
+.caret-yellow-600 {
+  caret-color: #d97706;
+}
+
+.caret-yellow-700 {
+  caret-color: #b45309;
+}
+
+.caret-yellow-800 {
+  caret-color: #92400e;
+}
+
+.caret-yellow-900 {
+  caret-color: #78350f;
+}
+
+.caret-green-50 {
+  caret-color: #ecfdf5;
+}
+
+.caret-green-100 {
+  caret-color: #d1fae5;
+}
+
+.caret-green-200 {
+  caret-color: #a7f3d0;
+}
+
+.caret-green-300 {
+  caret-color: #6ee7b7;
+}
+
+.caret-green-400 {
+  caret-color: #34d399;
+}
+
+.caret-green-500 {
+  caret-color: #10b981;
+}
+
+.caret-green-600 {
+  caret-color: #059669;
+}
+
+.caret-green-700 {
+  caret-color: #047857;
+}
+
+.caret-green-800 {
+  caret-color: #065f46;
+}
+
+.caret-green-900 {
+  caret-color: #064e3b;
+}
+
+.caret-blue-50 {
+  caret-color: #eff6ff;
+}
+
+.caret-blue-100 {
+  caret-color: #dbeafe;
+}
+
+.caret-blue-200 {
+  caret-color: #bfdbfe;
+}
+
+.caret-blue-300 {
+  caret-color: #93c5fd;
+}
+
+.caret-blue-400 {
+  caret-color: #60a5fa;
+}
+
+.caret-blue-500 {
+  caret-color: #3b82f6;
+}
+
+.caret-blue-600 {
+  caret-color: #2563eb;
+}
+
+.caret-blue-700 {
+  caret-color: #1d4ed8;
+}
+
+.caret-blue-800 {
+  caret-color: #1e40af;
+}
+
+.caret-blue-900 {
+  caret-color: #1e3a8a;
+}
+
+.caret-indigo-50 {
+  caret-color: #eef2ff;
+}
+
+.caret-indigo-100 {
+  caret-color: #e0e7ff;
+}
+
+.caret-indigo-200 {
+  caret-color: #c7d2fe;
+}
+
+.caret-indigo-300 {
+  caret-color: #a5b4fc;
+}
+
+.caret-indigo-400 {
+  caret-color: #818cf8;
+}
+
+.caret-indigo-500 {
+  caret-color: #6366f1;
+}
+
+.caret-indigo-600 {
+  caret-color: #4f46e5;
+}
+
+.caret-indigo-700 {
+  caret-color: #4338ca;
+}
+
+.caret-indigo-800 {
+  caret-color: #3730a3;
+}
+
+.caret-indigo-900 {
+  caret-color: #312e81;
+}
+
+.caret-purple-50 {
+  caret-color: #f5f3ff;
+}
+
+.caret-purple-100 {
+  caret-color: #ede9fe;
+}
+
+.caret-purple-200 {
+  caret-color: #ddd6fe;
+}
+
+.caret-purple-300 {
+  caret-color: #c4b5fd;
+}
+
+.caret-purple-400 {
+  caret-color: #a78bfa;
+}
+
+.caret-purple-500 {
+  caret-color: #8b5cf6;
+}
+
+.caret-purple-600 {
+  caret-color: #7c3aed;
+}
+
+.caret-purple-700 {
+  caret-color: #6d28d9;
+}
+
+.caret-purple-800 {
+  caret-color: #5b21b6;
+}
+
+.caret-purple-900 {
+  caret-color: #4c1d95;
+}
+
+.caret-pink-50 {
+  caret-color: #fdf2f8;
+}
+
+.caret-pink-100 {
+  caret-color: #fce7f3;
+}
+
+.caret-pink-200 {
+  caret-color: #fbcfe8;
+}
+
+.caret-pink-300 {
+  caret-color: #f9a8d4;
+}
+
+.caret-pink-400 {
+  caret-color: #f472b6;
+}
+
+.caret-pink-500 {
+  caret-color: #ec4899;
+}
+
+.caret-pink-600 {
+  caret-color: #db2777;
+}
+
+.caret-pink-700 {
+  caret-color: #be185d;
+}
+
+.caret-pink-800 {
+  caret-color: #9d174d;
+}
+
+.caret-pink-900 {
+  caret-color: #831843;
+}
+
 .opacity-0 {
   opacity: 0;
 }
@@ -29963,6 +30299,10 @@ select {
 
 .ease-in-out {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.content-none {
+  content: none;
 }
 
 #modal-container {

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -24,6 +24,13 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 		newFlagTitle = newFlagTitle.toLowerCase();
 		return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
 	};
+	const invalidRolloutPercentage = (rollout) => {
+		return rollout < 0 || rollout > 100;
+	};
+
+	const alertInvalidRolloutPercentage = () => {
+		alert(`Flag rollout percentage must be 0-100`);
+	};
 
 	const handleSubmit = (e) => {
 		e.preventDefault();
@@ -36,9 +43,13 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 			return;
 		}
 
-		if (flagRollout < 0 || flagRollout > 100) {
-			alert(`Flag rollout percentage must be 0-100`);
+		if (invalidRolloutPercentage) {
+			alertInvalidRolloutPercentage(flagRollout);
+			return;
 		}
+		// if (flagRollout < 0 || flagRollout > 100) {
+		// 	alert(`Flag rollout percentage must be 0-100`);
+		// }
 
 		const newFlag = { flag: { title: flagTitle, description: flagDescription, rollout: flagRollout } };
 		dispatch(
@@ -48,19 +59,6 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 			})
 		);
 	};
-
-	// const handleRolloutChange = (e) => {
-	// 	e.preventDefault();
-	// 	setFlagRollout(e.target.value);
-	// };
-
-	// const handleFlagTitleKeyDown = (e) => {
-	// 	setFlagTitle(e.target.value);
-	// };
-
-	// const handleFlagDescriptionKeydown = (e) => {
-	// 	setFlagDescription(e.target.value);
-	// };
 
 	return (
 		<FlagForm

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -1,123 +1,81 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { createFlag } from '../../actions/FlagActions';
+import FlagForm from '../sharedComponents/FlagForm';
 
+const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
+	const [ flagTitle, setFlagTitle ] = useState('');
+	const [ flagDescription, setFlagDescription ] = useState('');
+	const [ flagRollout, setFlagRollout ] = useState(0);
+	const dispatch = useDispatch();
 
-const NewFlagForm = ({creatingNew, setCreatingNew, existingFlags}) => {
-  const [ flagTitle, setFlagTitle ] = useState('');
-  const [ flagDescription, setFlagDescription ] = useState('');
-  const [ flagRollout, setFlagRollout ] = useState(0);
-  const dispatch = useDispatch();
+	const handleCancel = () => {
+		setCreatingNew(false);
+		resetFields();
+	};
 
-  const handleCancel = () => {
-    setCreatingNew(false);
-    resetFields();
-  };
+	const resetFields = () => {
+		setFlagDescription('');
+		setFlagTitle('');
+		setFlagRollout(0);
+	};
 
-  const resetFields = () => {
-    setFlagDescription('');
-    setFlagTitle('');
-    setFlagRollout(0);
-  };
+	const nameIsUnique = (newFlagTitle) => {
+		newFlagTitle = newFlagTitle.toLowerCase();
+		return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
+	};
 
-  const nameIsUnique = (newFlagTitle) => {
-    newFlagTitle = newFlagTitle.toLowerCase();
-    return existingFlags.every(flag => flag.title.toLowerCase() !== newFlagTitle);
-  };
+	const handleSubmit = (e) => {
+		e.preventDefault();
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
+		if (flagTitle === '') {
+			alert('You must have a flag title');
+			return;
+		} else if (!nameIsUnique(flagTitle)) {
+			alert(`The flag name ${flagTitle} has already been used. Please choose another.`);
+			return;
+		}
 
-    if (flagTitle === '') {
-      alert("You must have a flag title");
-      return;
-    } else if (!nameIsUnique(flagTitle)) {
-      alert(`The flag name ${flagTitle} has already been used. Please choose another.`);
-      return;
-    }
+		if (flagRollout < 0 || flagRollout > 100) {
+			alert(`Flag rollout percentage must be 0-100`);
+		}
 
-    if (flagRollout < 0 || flagRollout > 100) {
-      alert(`Flag rollout percentage must be 0-100`);
-    }
+		const newFlag = { flag: { title: flagTitle, description: flagDescription, rollout: flagRollout } };
+		dispatch(
+			createFlag(newFlag, () => {
+				setCreatingNew(false);
+				resetFields();
+			})
+		);
+	};
 
-    const newFlag = { flag: { title: flagTitle, description: flagDescription, rollout: flagRollout }};
-    dispatch(createFlag(newFlag, () => {
-      setCreatingNew(false)
-      resetFields();
-    }));
-  };
+	// const handleRolloutChange = (e) => {
+	// 	e.preventDefault();
+	// 	setFlagRollout(e.target.value);
+	// };
 
-  const handleRolloutChange = (e) => {
-    e.preventDefault();
-    setFlagRollout(e.target.value)
-  };
+	// const handleFlagTitleKeyDown = (e) => {
+	// 	setFlagTitle(e.target.value);
+	// };
 
-  const handleFlagTitleKeyDown = (e) => {
-    setFlagTitle(e.target.value);
-  }
+	// const handleFlagDescriptionKeydown = (e) => {
+	// 	setFlagDescription(e.target.value);
+	// };
 
-  const handleFlagDescriptionKeydown = (e) => {
-    setFlagDescription(e.target.value);
-  }
-
-  return(
-    <div id="modal-container" className={`overflow-scroll fixed ${creatingNew ? "" : "hidden"}`}>
-      <div id="modal">
-        <form onSubmit={handleSubmit} className="space-y-8 divide-y divide-gray-200 m-8">
-          <div className="space-y-8 divide-y divide-gray-200 sm:space-y-5 p-6">
-            <div>
-              <div>
-                <h3 className="text-lg leading-6 font-medium text-gray-900">
-                  New Flag
-                </h3>
-                <p className="mt-1 max-w-2xl text-sm text-gray-500">
-                  We recommend giving your flag a descriptive title and providing a brief description. All flags are created in 'off' mode. You can toggle the flag on after it's been saved.
-                </p>
-              </div>
-              <div className="space-y-6 sm:space-y-5">
-              <div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                <label htmlFor="first-name" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                  Flag title
-                </label>
-                <div className="mt-1 sm:mt-0 sm:col-span-2">
-                  <input onChange={handleFlagTitleKeyDown} type="text" autoComplete="given-name" className="max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md" value={flagTitle}></input>
-                </div>
-              </div>
-              </div>
-              <div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                <label htmlFor="about" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                  Description
-                </label>
-                <div className="mt-1 sm:mt-0 sm:col-span-2">
-                  <textarea onChange={handleFlagDescriptionKeydown} value={flagDescription} rows="3" className="max-w-lg shadow-sm block w-full focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"></textarea>
-                  <p className="mt-2 text-sm text-gray-500">Write a few sentences about the purpose of the flag.</p>
-                </div>
-              </div>
-            </div>
-            <div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-              <label htmlFor="about" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                Rollout percentage
-              </label>
-              <div className="mt-1 sm:mt-0 sm:col-span-2">
-                <input type="number" onInput={handleRolloutChange} value={flagRollout} min="0" max="100" className="shadow-sm block focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"></input>
-                <p className="mt-2 text-sm text-gray-500">
-                  Rollout percentage must be between 0-100. If you do not provide a rollout percentage, a default of 0% will be assigned.
-                </p>
-              </div>
-            </div>
-            <div className="clear-both py-10 mb-10">
-              <button onClick={handleSubmit} type="button" className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                Save
-              </button>
-              <button type="button" onClick={handleCancel} className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                Cancel
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
+	return (
+		<FlagForm
+			formContext="new"
+			formVisibility={creatingNew}
+			flagTitle={flagTitle}
+			setFlagTitle={setFlagTitle}
+			flagDescription={flagDescription}
+			setFlagDescription={setFlagDescription}
+			flagRollout={flagRollout}
+			setFlagRollout={setFlagRollout}
+			handleCancel={handleCancel}
+			handleSubmit={handleSubmit}
+		/>
+	);
 };
 
 export default NewFlagForm;

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { createFlag } from '../../actions/FlagActions';
 import FlagForm from '../sharedComponents/FlagForm';
-import { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique } from '../../lib/formHelpers';
+import {
+	invalidRolloutPercentage,
+	alertInvalidRolloutPercentage,
+	nameIsUnique,
+	alertEmptyTitle,
+	alertRedundantTitle
+} from '../../lib/formHelpers';
 
 const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 	const [ flagTitle, setFlagTitle ] = useState('');
@@ -25,10 +31,10 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 		e.preventDefault();
 
 		if (flagTitle === '') {
-			alert('You must have a flag title');
+			alertEmptyTitle();
 			return;
 		} else if (!nameIsUnique(flagTitle, existingFlags)) {
-			alert(`The flag name ${flagTitle} has already been used. Please choose another.`);
+			alertRedundantTitle(flagTitle);
 			return;
 		}
 

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { createFlag } from '../../actions/FlagActions';
 import FlagForm from '../sharedComponents/FlagForm';
-import { invalidRolloutPercentage, alertInvalidRolloutPercentage } from '../../lib/formHelpers';
+import { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique } from '../../lib/formHelpers';
 
 const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 	const [ flagTitle, setFlagTitle ] = useState('');
@@ -21,18 +21,13 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 		setFlagRollout(0);
 	};
 
-	const nameIsUnique = (newFlagTitle) => {
-		newFlagTitle = newFlagTitle.toLowerCase();
-		return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
-	};
-
 	const handleSubmit = (e) => {
 		e.preventDefault();
 
 		if (flagTitle === '') {
 			alert('You must have a flag title');
 			return;
-		} else if (!nameIsUnique(flagTitle)) {
+		} else if (!nameIsUnique(flagTitle, existingFlags)) {
 			alert(`The flag name ${flagTitle} has already been used. Please choose another.`);
 			return;
 		}
@@ -41,9 +36,6 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 			alertInvalidRolloutPercentage(flagRollout);
 			return;
 		}
-		// if (flagRollout < 0 || flagRollout > 100) {
-		// 	alert(`Flag rollout percentage must be 0-100`);
-		// }
 
 		const newFlag = { flag: { title: flagTitle, description: flagDescription, rollout: flagRollout } };
 		dispatch(

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -32,8 +32,8 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 			return;
 		}
 
-		if (invalidRolloutPercentage) {
-			alertInvalidRolloutPercentage(flagRollout);
+		if (invalidRolloutPercentage(flagRollout)) {
+			alertInvalidRolloutPercentage();
 			return;
 		}
 

--- a/client/src/components/dashboardComponents/NewFlagForm.jsx
+++ b/client/src/components/dashboardComponents/NewFlagForm.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { createFlag } from '../../actions/FlagActions';
 import FlagForm from '../sharedComponents/FlagForm';
+import { invalidRolloutPercentage, alertInvalidRolloutPercentage } from '../../lib/formHelpers';
 
 const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 	const [ flagTitle, setFlagTitle ] = useState('');
@@ -23,13 +24,6 @@ const NewFlagForm = ({ creatingNew, setCreatingNew, existingFlags }) => {
 	const nameIsUnique = (newFlagTitle) => {
 		newFlagTitle = newFlagTitle.toLowerCase();
 		return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
-	};
-	const invalidRolloutPercentage = (rollout) => {
-		return rollout < 0 || rollout > 100;
-	};
-
-	const alertInvalidRolloutPercentage = () => {
-		alert(`Flag rollout percentage must be 0-100`);
 	};
 
 	const handleSubmit = (e) => {

--- a/client/src/components/flagViewComponents/EditFlagForm.jsx
+++ b/client/src/components/flagViewComponents/EditFlagForm.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateFlag } from '../../actions/FlagActions';
+import FlagForm from '../sharedComponents/FlagForm';
+import { invalidRolloutPercentage, alertInvalidRolloutPercentage } from '../../lib/formHelpers';
 
 const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 	const [ flagTitle, setFlagTitle ] = useState(flag.title);
@@ -27,8 +29,8 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 			return;
 		}
 
-		if (flagRollout < 0 || flagRollout > 100) {
-			alert('Flag rollout percentage must be 0-100.');
+		if (invalidRolloutPercentage) {
+			alertInvalidRolloutPercentage(flagRollout);
 			return;
 		}
 
@@ -37,7 +39,7 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 			title       : flagTitle,
 			description : flagDescription,
 			is_active   : flag.is_active,
-			rollout     : flagRollout,
+			rollout     : flagRollout
 		};
 
 		dispatch(
@@ -48,93 +50,19 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 		);
 	};
 
-  const handleRolloutChange = (e) => {
-    e.preventDefault();
-    setFlagRollout(e.target.value)
-  };
-
-	const handleFlagTitleKeyDown = (e) => {
-		setFlagTitle(e.target.value);
-	};
-
-	const handleFlagDescriptionKeydown = (e) => {
-		setFlagDescription(e.target.value);
-	};
-
 	return (
-		<div id="modal-container" className={`overflow-scroll fixed ${editingFlag ? '' : 'hidden'}`}>
-			<div id="modal">
-				<form onSubmit={handleSubmit} className="space-y-8 divide-y divide-gray-200 m-8">
-					<div className="space-y-8 divide-y divide-gray-200 sm:space-y-5 p-6">
-						<div>
-							<div>
-								<h3 className="text-lg leading-6 font-medium text-gray-900">Edit Flag</h3>
-								<p className="mt-1 max-w-2xl text-sm text-gray-500">
-									You can edit the title or description of your flag here. Entries cannot be blank, so don't try it!
-								</p>
-							</div>
-							<div className="space-y-6 sm:space-y-5">
-								<div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-									<label htmlFor="first-name" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-										Flag title
-									</label>
-									<div className="mt-1 sm:mt-0 sm:col-span-2">
-										<input
-											onChange={handleFlagTitleKeyDown}
-											type="text"
-											autoComplete="given-name"
-											className="max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
-											value={flagTitle}
-										/>
-									</div>
-								</div>
-							</div>
-							<div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-								<label htmlFor="about" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-									Description
-								</label>
-								<div className="mt-1 sm:mt-0 sm:col-span-2">
-									<textarea
-										onChange={handleFlagDescriptionKeydown}
-										value={flagDescription}
-										rows="3"
-										className="max-w-lg shadow-sm block w-full focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"
-									/>
-									<p className="mt-2 text-sm text-gray-500">Write a few sentences about the purpose of the flag.</p>
-								</div>
-							</div>
-						</div>
-						<div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-              <label htmlFor="about" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                Rollout percentage
-              </label>
-              <div className="mt-1 sm:mt-0 sm:col-span-2">
-                <input type="number" onInput={handleRolloutChange} value={flagRollout} min="0" max="100" className="shadow-sm block focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"></input>
-                <p className="mt-2 text-sm text-gray-500">
-                  Rollout percentage must be between 0-100. If you do not provide a rollout percentage, a default of 0% will be assigned.
-                </p>
-              </div>
-            </div>
-						<div className="clear-both py-10 mb-10">
-							<button
-								onClick={handleSubmit}
-								type="button"
-								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-							>
-								Save
-							</button>
-							<button
-								type="button"
-								onClick={handleCancel}
-								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-							>
-								Cancel
-							</button>
-						</div>
-					</div>
-				</form>
-			</div>
-		</div>
+		<FlagForm
+			formContext="edit"
+			formVisibility={editingFlag}
+			flagTitle={flagTitle}
+			setFlagTitle={setFlagTitle}
+			flagDescription={flagDescription}
+			setFlagDescription={setFlagDescription}
+			flagRollout={flagRollout}
+			setFlagRollout={setFlagRollout}
+			handleCancel={handleCancel}
+			handleSubmit={handleSubmit}
+		/>
 	);
 };
 

--- a/client/src/components/flagViewComponents/EditFlagForm.jsx
+++ b/client/src/components/flagViewComponents/EditFlagForm.jsx
@@ -29,7 +29,7 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 			return;
 		}
 
-		if (invalidRolloutPercentage()) {
+		if (invalidRolloutPercentage(flagRollout)) {
 			alertInvalidRolloutPercentage();
 			return;
 		}

--- a/client/src/components/flagViewComponents/EditFlagForm.jsx
+++ b/client/src/components/flagViewComponents/EditFlagForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateFlag } from '../../actions/FlagActions';
 import FlagForm from '../sharedComponents/FlagForm';
-import { invalidRolloutPercentage, alertInvalidRolloutPercentage, alertRedundantTitle } from '../../lib/formHelpers';
+import { invalidRolloutPercentage, alertInvalidRolloutPercentage, alertEmptyTitle } from '../../lib/formHelpers';
 
 const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 	const [ flagTitle, setFlagTitle ] = useState(flag.title);
@@ -25,7 +25,7 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 	const handleSubmit = (e) => {
 		e.preventDefault();
 		if (flagTitle === '') {
-			alertRedundantTitle();
+			alertEmptyTitle();
 			return;
 		}
 

--- a/client/src/components/flagViewComponents/EditFlagForm.jsx
+++ b/client/src/components/flagViewComponents/EditFlagForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateFlag } from '../../actions/FlagActions';
 import FlagForm from '../sharedComponents/FlagForm';
-import { invalidRolloutPercentage, alertInvalidRolloutPercentage } from '../../lib/formHelpers';
+import { invalidRolloutPercentage, alertInvalidRolloutPercentage, alertRedundantTitle } from '../../lib/formHelpers';
 
 const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 	const [ flagTitle, setFlagTitle ] = useState(flag.title);
@@ -25,7 +25,7 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 	const handleSubmit = (e) => {
 		e.preventDefault();
 		if (flagTitle === '') {
-			alert('You must have a flag title');
+			alertRedundantTitle();
 			return;
 		}
 

--- a/client/src/components/flagViewComponents/EditFlagForm.jsx
+++ b/client/src/components/flagViewComponents/EditFlagForm.jsx
@@ -29,8 +29,8 @@ const EditFlagForm = ({ editingFlag, setEditingFlag, flag }) => {
 			return;
 		}
 
-		if (invalidRolloutPercentage) {
-			alertInvalidRolloutPercentage(flagRollout);
+		if (invalidRolloutPercentage()) {
+			alertInvalidRolloutPercentage();
 			return;
 		}
 

--- a/client/src/components/sharedComponents/FlagForm.jsx
+++ b/client/src/components/sharedComponents/FlagForm.jsx
@@ -97,8 +97,7 @@ const FlagForm = ({
 									className="shadow-sm block focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"
 								/>
 								<p className="mt-2 text-sm text-gray-500">
-									Rollout percentage must be between 0-100. If you do not provide a rollout percentage, a default of 0%
-									will be assigned.
+									Rollout percentage must be between 0-100.
 								</p>
 							</div>
 						</div>

--- a/client/src/components/sharedComponents/FlagForm.jsx
+++ b/client/src/components/sharedComponents/FlagForm.jsx
@@ -1,0 +1,128 @@
+// flag form will take state/set for form visibility, and an arg to define the context('edit' or 'new')
+// title, desc, rollout as well
+// it will need to accecpt methods for handleCancel, resetFields, handleSubmit
+// it will define handle value change methods 50-62
+// the html will have conditional rendering for the title and description labels
+
+import React from 'react';
+
+const FlagForm = ({
+	formContext,
+	formVisibility,
+	flagTitle,
+	setFlagTitle,
+	flagDescription,
+	setFlagDescription,
+	flagRollout,
+	setFlagRollout,
+	handleCancel,
+	handleSubmit
+}) => {
+	// check if form is an edit form or a new flag form
+	const formContextIsEdit = formContext === 'edit';
+
+	const handleRolloutChange = (e) => {
+		e.preventDefault();
+		setFlagRollout(e.target.value);
+	};
+
+	const handleFlagTitleKeyDown = (e) => {
+		setFlagTitle(e.target.value);
+	};
+
+	const handleFlagDescriptionKeydown = (e) => {
+		setFlagDescription(e.target.value);
+	};
+
+	return (
+		<div id="modal-container" className={`overflow-scroll fixed ${formVisibility ? '' : 'hidden'}`}>
+			<div id="modal">
+				<form onSubmit={handleSubmit} className="space-y-8 divide-y divide-gray-200 m-8">
+					<div className="space-y-8 divide-y divide-gray-200 sm:space-y-5 p-6">
+						<div>
+							<div>
+								<h3 className="text-lg leading-6 font-medium text-gray-900">
+									{formContextIsEdit ? 'Edit' : 'New'} Flag
+								</h3>
+								<p className="mt-1 max-w-2xl text-sm text-gray-500">
+									{formContextIsEdit ? (
+										'You can edit the title or description of your flag here.'
+									) : (
+										"We recommend giving your flag a descriptive title and providing a brief description. All flags are created in 'off' mode. You can toggle the flag on after it's been saved."
+									)}
+								</p>
+							</div>
+							<div className="space-y-6 sm:space-y-5">
+								<div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
+									<label htmlFor="first-name" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
+										Flag title
+									</label>
+									<div className="mt-1 sm:mt-0 sm:col-span-2">
+										<input
+											onChange={handleFlagTitleKeyDown}
+											type="text"
+											autoComplete="given-name"
+											className="max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
+											value={flagTitle}
+										/>
+									</div>
+								</div>
+							</div>
+							<div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
+								<label htmlFor="about" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
+									Description
+								</label>
+								<div className="mt-1 sm:mt-0 sm:col-span-2">
+									<textarea
+										onChange={handleFlagDescriptionKeydown}
+										value={flagDescription}
+										rows="3"
+										className="max-w-lg shadow-sm block w-full focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"
+									/>
+									<p className="mt-2 text-sm text-gray-500">Write a few sentences about the purpose of the flag.</p>
+								</div>
+							</div>
+						</div>
+						<div className="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
+							<label htmlFor="about" className="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
+								Rollout percentage
+							</label>
+							<div className="mt-1 sm:mt-0 sm:col-span-2">
+								<input
+									type="number"
+									onInput={handleRolloutChange}
+									value={flagRollout}
+									min="0"
+									max="100"
+									className="shadow-sm block focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm border border-gray-300 rounded-md"
+								/>
+								<p className="mt-2 text-sm text-gray-500">
+									Rollout percentage must be between 0-100. If you do not provide a rollout percentage, a default of 0%
+									will be assigned.
+								</p>
+							</div>
+						</div>
+						<div className="clear-both py-10 mb-10">
+							<button
+								onClick={handleSubmit}
+								type="button"
+								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+							>
+								Save
+							</button>
+							<button
+								type="button"
+								onClick={handleCancel}
+								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+};
+
+export default FlagForm;

--- a/client/src/lib/formHelpers.js
+++ b/client/src/lib/formHelpers.js
@@ -1,6 +1,9 @@
 // is the rollout value given within the valid parameters?
 const invalidRolloutPercentage = (rollout) => {
-	return rollout < 0 || rollout > 100;
+	return rollout === '' ||
+				 	isNaN(rollout) ||
+				 	Number(rollout) < 0 ||
+					Number(rollout) > 100;
 };
 
 // alert the client if invalid rollout was given

--- a/client/src/lib/formHelpers.js
+++ b/client/src/lib/formHelpers.js
@@ -8,9 +8,14 @@ const alertInvalidRolloutPercentage = () => {
 	alert(`Flag rollout percentage must be 0-100`);
 };
 
+const alertRedundantTitle = () => {
+	alert('You must have a flag title');
+};
+
+// check if name is unique among array of flags
 const nameIsUnique = (newFlagTitle, existingFlags = []) => {
 	newFlagTitle = newFlagTitle.toLowerCase();
 	return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
 };
 
-export { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique };
+export { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique, alertRedundantTitle };

--- a/client/src/lib/formHelpers.js
+++ b/client/src/lib/formHelpers.js
@@ -8,4 +8,9 @@ const alertInvalidRolloutPercentage = () => {
 	alert(`Flag rollout percentage must be 0-100`);
 };
 
-export { invalidRolloutPercentage, alertInvalidRolloutPercentage };
+const nameIsUnique = (newFlagTitle, existingFlags = []) => {
+	newFlagTitle = newFlagTitle.toLowerCase();
+	return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
+};
+
+export { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique };

--- a/client/src/lib/formHelpers.js
+++ b/client/src/lib/formHelpers.js
@@ -8,8 +8,12 @@ const alertInvalidRolloutPercentage = () => {
 	alert(`Flag rollout percentage must be 0-100`);
 };
 
-const alertRedundantTitle = () => {
+const alertEmptyTitle = () => {
 	alert('You must have a flag title');
+};
+
+const alertRedundantTitle = (flagTitle) => {
+	alert(`The flag name ${flagTitle} has already been used. Please choose another.`);
 };
 
 // check if name is unique among array of flags
@@ -18,4 +22,4 @@ const nameIsUnique = (newFlagTitle, existingFlags = []) => {
 	return existingFlags.every((flag) => flag.title.toLowerCase() !== newFlagTitle);
 };
 
-export { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique, alertRedundantTitle };
+export { invalidRolloutPercentage, alertInvalidRolloutPercentage, nameIsUnique, alertEmptyTitle, alertRedundantTitle };

--- a/client/src/lib/formHelpers.js
+++ b/client/src/lib/formHelpers.js
@@ -1,0 +1,11 @@
+// is the rollout value given within the valid parameters?
+const invalidRolloutPercentage = (rollout) => {
+	return rollout < 0 || rollout > 100;
+};
+
+// alert the client if invalid rollout was given
+const alertInvalidRolloutPercentage = () => {
+	alert(`Flag rollout percentage must be 0-100`);
+};
+
+export { invalidRolloutPercentage, alertInvalidRolloutPercentage };

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -29,8 +29,9 @@ const getFlag = async (req, res, next) => {
 
 const createFlag = async (req, res, next) => {
 	const errors = validationResult(req);
-	if (errors.isEmpty()) {
-		const { title, description, rollout } = req.body.flag;
+	const { title, description, rollout } = req.body.flag;
+
+	if (errors.isEmpty() && rollout !== '') {
 		await createFlagDb(title, description, rollout)
 			.then((flag) => {
 				req.flag = flag;
@@ -62,8 +63,6 @@ const updateFlag = async (req, res, next) => {
 	const flag = req.body.flag;
 	const toggleChange = req.body.toggleChange;
 	const errors = validationResult(req);
-
-	console.log("\n\n flag: ", flag);
 
 	if (errors.isEmpty()) {
 		await updateFlagDb(id, flag.title, flag.description, flag.is_active, flag.rollout)


### PR DESCRIPTION
This was a refactor of existing components; namely, extracting the overlapping code for `NewFlagForm` and `EditFlagForm`.

They both had a good deal of overlapping code, though their implementations of a few key methods, like `handleSubmit` and the interdependent relationship of these unique implementations with some of the overlapping code made this difficult to fully extricate. 

My attempt here pulls out the HTML template into a separate component, since that was a huge chunk of the overlap, and uses a basic context check to conditionally render text relevant to the edit or new versions of the form.
I left the definition of many of the methods for handling the form interactions in their respective forms (`handleCancel`, `handleSubmit`, `resetFields`) along with the relevant state elements (`flagTitle`, `setFlagTitle`, etc), again due to the intertwined nature of these pieces. Instead, we now just pass these pieces into the `FlagForm` which can then handle the interactions.

There were some redundant sections that I chose to extract to a separate file `client/lib/formHelper`; these were generally used in both the edit and new form's unique implementations of `handleSubmit`, so though I couldn't extract the whole function, I was able to at least remove a good amount of redundant code.

Overall, tests indicate both adding and editing flags are functional with updates. Please double check and verify before merging.