### PR TITLE
Handle uncaught errors nats

### DIFF
--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -1,6 +1,5 @@
 const HttpError = require('../models/httpError');
 const { validationResult } = require('express-validator');
-// const { publishUpdatedRules } = require('../lib/nats/nats-pub');
 const jsw = require('../lib/nats/jsw');
 const { createFlagDb, fetchAllFlags, fetchFlag, updateFlagDb, deleteFlagDb } = require('../lib/db/flags');
 

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -35,7 +35,7 @@ const createFlag = async (req, res, next) => {
 		await createFlagDb(title, description, rollout)
 			.then((flag) => {
 				req.flag = flag;
-				jsw.publishUpdatedRules();
+				jsw.publishUpdatedRules().catch(err => console.error("There was an error publishing the updated ruleset to NATS."));
 				next();
 			})
 			.catch((err) => {
@@ -70,7 +70,7 @@ const updateFlag = async (req, res, next) => {
 				req.flag = flag;
 				req.toggleChange = toggleChange;
 
-				jsw.publishUpdatedRules();
+				jsw.publishUpdatedRules().catch(err => console.error("There was an error publishing the updated ruleset to NATS"));
 				next();
 			})
 			.catch(err => {
@@ -89,7 +89,7 @@ const deleteFlag = async (req, res, next) => {
 	await deleteFlagDb(id)
 		.then((deleteSuccess) => {
 			if (deleteSuccess) {
-				jsw.publishUpdatedRules();
+				jsw.publishUpdatedRules().catch(err => console.error("There was an error publishing the updated ruleset to NATS"));
 
 				res.send({ id });
 			} else {

--- a/server/controllers/sdkKeysController.js
+++ b/server/controllers/sdkKeysController.js
@@ -8,7 +8,7 @@ const getSdkKey = async (req, res, next) => {
 		.then((key) => {
 			console.log('fetching sdk key');
 			const sdkKey = key;
-			publishSdkKey();
+			publishSdkKey().catch(err => console.error("There was an error publishing the new sdkKey to NATS"));
 			res.json({ sdkKey });
 		})
 		.catch((err) => {

--- a/server/index.js
+++ b/server/index.js
@@ -34,5 +34,5 @@ app.use((err, req, res, next) => {
 
 app.listen(PORT, async () => {
 	console.log(`Server listening on ${PORT}`);
-	await jsw.init().catch(err => console.error("NATS connection failed"));
+	await jsw.init().catch(err => console.error("NATS connection failed", err));
 });

--- a/server/index.js
+++ b/server/index.js
@@ -34,5 +34,5 @@ app.use((err, req, res, next) => {
 
 app.listen(PORT, async () => {
 	console.log(`Server listening on ${PORT}`);
-	await jsw.init();
+	await jsw.init().catch(err => console.error("NATS connection failed"));
 });

--- a/server/lib/nats/jetstreamManager.js
+++ b/server/lib/nats/jetstreamManager.js
@@ -8,7 +8,9 @@ async function createJetStreamConnect() {
 }
 
 async function createStreams() {
-	await createJetStreamConnect();
+	await createJetStreamConnect().catch(err => {
+		throw Error(err, "NATS connection failed")
+	});
 	const jsm = await nc.jetstreamManager();
 
 	jsm.streams.add({ name: 'DATA', subjects: [ 'DATA.*' ], storage: 'memory', max_msgs: 1 }); //max_age: 300000000})
@@ -33,7 +35,10 @@ async function addConsumers(jsm) {
 }
 
 async function streamsCreated() {
-	await createJetStreamConnect();
+	await createJetStreamConnect().catch(err => {
+		throw new Error(err)
+	});
+	
 	const jsm = await nc.jetstreamManager();
 
 	let data;

--- a/server/lib/nats/jsw.js
+++ b/server/lib/nats/jsw.js
@@ -10,9 +10,7 @@ class JetstreamWrapper {
 
 	// create streams, create consumers, create subscriptions
 	async init() {
-		await this._createJetStreamConnect().catch(err => {
-			throw Error(err, "Error initializing JetStream connection");
-		});
+		await this._createJetStreamConnect();
 
 		if (!await this._checkStreamsCreated()) {
 			await this._createStreams();
@@ -69,7 +67,7 @@ class JetstreamWrapper {
 		});
 		// put the server address and port in an env variable?
 
-		this.js = await this.nc.jetstream().catch(err => console.error(err));
+		this.js = this.nc.jetstream()
 		this.jsm = await this.nc.jetstreamManager().catch(err => console.error(err));
 	}
 

--- a/server/lib/nats/jsw.js
+++ b/server/lib/nats/jsw.js
@@ -77,17 +77,23 @@ class JetstreamWrapper {
 		const json = JSON.stringify(data);
 		const encodedData = this.sc.encode(json);
 		console.log(`Publishing this msg: ${json} to this stream: '${streamName}'`);
-		const pubMsg = await this.js.publish(streamName, encodedData);
+		const pubMsg = await this.js.publish(streamName, encodedData).catch(err => {
+			throw Error(err, "Publish message failed. There is no connected stream.");
+		});
 	}
 
 	async publishUpdatedRules() {
 		let flagData = await fetchAllFlags();
-		await this._publish({ data: flagData, streamName: ruleset.fullSubject });
+		await this._publish({ data: flagData, streamName: ruleset.fullSubject }).catch(err => {
+			throw Error(err, "Cannot publish; there is no stream connected.");
+		});
 	}
 
 	async publishSdkKey() {
 		let fetchedSdkKey = await fetchUsersSdkKey();
-		await this._publish({ data: fetchedSdkKey, streamName: sdkKey.fullSubject });
+		await this._publish({ data: fetchedSdkKey, streamName: sdkKey.fullSubject }).catch(err => {
+			throw Error(err, "Cannot publish; there is no stream connected.");
+		});
 	}
 
 	async _createStreams() {
@@ -96,7 +102,7 @@ class JetstreamWrapper {
 			subjects : [ `${ruleset.streamName}.*` ],
 			storage  : 'memory',
 			max_msgs : 1
-		}); //max_age: 300000000})
+		});
 		this.jsm.streams.add({
 			name     : sdkKey.streamName,
 			subjects : [ `${sdkKey.streamName}.*` ],

--- a/server/lib/nats/jsw.js
+++ b/server/lib/nats/jsw.js
@@ -64,9 +64,11 @@ class JetstreamWrapper {
 	}
 
 	async _createJetStreamConnect() {
-		this.nc = await connect({ servers: 'localhost:4222' }); // put the server address and port in an env variable?
-		this.js = await this.nc.jetstream();
-		this.jsm = await this.nc.jetstreamManager();
+		this.nc = await connect({ servers: 'localhost:4222' }).catch(err => console.error(err));
+		// put the server address and port in an env variable?
+		if (!this.nc) { return }; // if this.nc is undefined, don't run next two lines
+		this.js = await this.nc.jetstream().catch(err => console.error(err));
+		this.jsm = await this.nc.jetstreamManager().catch(err => console.error(err));
 	}
 
 	async _publish({ data, streamName }) {
@@ -85,8 +87,6 @@ class JetstreamWrapper {
 		let fetchedSdkKey = await fetchUsersSdkKey();
 		await this._publish({ data: fetchedSdkKey, streamName: sdkKey.fullSubject });
 	}
-
-	// everything below was refactored from jetstreamManager.js
 
 	async _createStreams() {
 		this.jsm.streams.add({
@@ -125,7 +125,6 @@ class JetstreamWrapper {
 
 			return data.config.name === ruleset.streamName && key.config.name === sdkKey.streamName;
 		} catch (err) {
-			//console.log('stream not created.', err);
 			return false;
 		}
 	}

--- a/server/lib/nats/nats-pub.js
+++ b/server/lib/nats/nats-pub.js
@@ -15,7 +15,9 @@ async function createJetStreamConnect() {
 
 // publishing to jetstream
 async function publishUpdatedRules() {
-    await createJetStreamConnect();
+    await createJetStreamConnect().catch(err => {
+      throw new Error(err, "JetStream connect failed");
+    });
 
   if (! await streamsCreated()) {
     await createStreams();
@@ -35,7 +37,7 @@ async function publishSdkKey() {
   if (! await streamsCreated()) {
     await createStreams();
   }
-  
+
   let sdkKey = await fetchUsersSdkKey();
   sdkKey = JSON.stringify(sdkKey);
   console.log(`Publishing this msg: ${sdkKey} to this stream: 'KEY.sdkKey'`);

--- a/server/lib/nats/nats-pub.js
+++ b/server/lib/nats/nats-pub.js
@@ -27,7 +27,9 @@ async function publishUpdatedRules() {
   flagData = JSON.stringify(flagData);
   console.log(`Publishing this msg: ${(flagData)} to this stream: 'DATA.FullRuleSet'`)
 
-  const pubMsg = await js.publish('DATA.FullRuleSet', sc.encode(flagData))
+  const pubMsg = await js.publish('DATA.FullRuleSet', sc.encode(flagData)).catch(err => {
+    throw Error(err, "Cannot publish flag data. No connected Jetstream to publish to.");
+  });
 
 }
 
@@ -42,7 +44,9 @@ async function publishSdkKey() {
   sdkKey = JSON.stringify(sdkKey);
   console.log(`Publishing this msg: ${sdkKey} to this stream: 'KEY.sdkKey'`);
 
-  const pubMsg = await js.publish('KEY.sdkKey', sc.encode(sdkKey));
+  const pubMsg = await js.publish('KEY.sdkKey', sc.encode(sdkKey)).catch(err => {
+    throw Error(err, "Cannot publish SDK key; no JetStream connected.");
+  });
 }
 
 async function subscribeToRuleSetRequests() {


### PR DESCRIPTION
This PR addresses the 'Uncaught promise rejection' warnings that were being printed each time there is an issue with publishing to or connecting to NATS.  Essentially, the PR adds error handling via `catch()` blocks to the asynchronous NATS connection and publish functions.

Now, if the user is running the app and the application fails to connect or publish to NATS (e.g. the user started Pioneer but NATS was not yet running), a helpful error message is displayed in the terminal.