### PR TITLE
add rate limit middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const HttpError = require('./models/httpError');
 const routes = require('./routes/api');
-// const { publishUpdatedRules, initSubscriptions } = require('./lib/nats/nats-pub');
+const rateLimit = require("express-rate-limit");
 const jsw = require('./lib/nats/jsw');
 const {fetchUsersSdkKey} = require('./lib/db/sdkKeys');
 require('dotenv').config();
@@ -9,6 +9,12 @@ require('dotenv').config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+const limiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 200 // limit each IP to 100 requests per windowMs
+});
+
+app.use(limiter);
 app.use((req, res, next) => {
 	res.header('Access-Control-Allow-Origin', '*');
 	res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const PORT = process.env.PORT || 3001;
 
 const limiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes
-  max: 200 // limit each IP to 100 requests per windowMs
+  max: 200 // limit each IP to 200 requests per windowMs
 });
 
 app.use(limiter);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
 				"concurrently": "^6.2.0",
 				"dotenv": "^10.0.0",
 				"express": "^4.17.1",
+				"express-rate-limit": "^5.3.0",
 				"express-validator": "^6.12.0",
 				"jest": "^27.0.6",
 				"mongoose": "^5.13.2",
@@ -2699,6 +2700,11 @@
 			"engines": {
 				"node": ">= 0.10.0"
 			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.3.0.tgz",
+			"integrity": "sha512-qJhfEgCnmteSeZAeuOKQ2WEIFTX5ajrzE0xS6gCOBCoRQcU+xEzQmgYQQTpzCcqUAAzTEtu4YEih4pnLfvNtew=="
 		},
 		"node_modules/express-validator": {
 			"version": "6.12.0",
@@ -9960,6 +9966,11 @@
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			}
+		},
+		"express-rate-limit": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.3.0.tgz",
+			"integrity": "sha512-qJhfEgCnmteSeZAeuOKQ2WEIFTX5ajrzE0xS6gCOBCoRQcU+xEzQmgYQQTpzCcqUAAzTEtu4YEih4pnLfvNtew=="
 		},
 		"express-validator": {
 			"version": "6.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
 		"concurrently": "^6.2.0",
 		"dotenv": "^10.0.0",
 		"express": "^4.17.1",
+		"express-rate-limit": "^5.3.0",
 		"express-validator": "^6.12.0",
 		"jest": "^27.0.6",
 		"mongoose": "^5.13.2",


### PR DESCRIPTION
This PR adds rate-limiting middleware to our Pioneer server.

The relevant code is in `Index.js`:

```js
const limiter = rateLimit({
  windowMs: 10 * 60 * 1000, // 10 minutes
  max: 200 // limit each IP to 200 requests per windowMs
});

app.use(limiter);
```

Each individual IP address (user) is limited to 200 requests every 10 minutes. We can definitely change these numbers if you all think a different amount is better.  The example code for the rate limiter used a max of 100 requests per IP address every 15 minutes. That seemed a bit low to me.

You can easily test this out on your own.  Temporarily change the code to this:

```js
const limiter = rateLimit({
  windowMs: 1 * 60 * 1000, // 1 minutes
  max: 2 // limit each IP to 2 requests per windowMs
});

app.use(limiter);
```

Now, the rate limiter is limiting a user to 2 requests each minute.  Run Pioneer's server and open up postman.  Send three `GET localhost:3001/flags` requests in a row, and on the third request you will see the following message indicating that the rate-limiting is working as expected:
<img width="390" alt="Screen Shot 2021-07-19 at 2 23 36 PM" src="https://user-images.githubusercontent.com/19399698/126216180-8f4c0a7a-3edc-4171-a5c1-b36eb4d2fe12.png">


Note that to test this, you'll have to run `npm install` in the `/server` dir.

On the UI side of things, if the rate limit is hit, the user will be presented with the 500 error screen.